### PR TITLE
A github actions workflow to notify if building the extension fails

### DIFF
--- a/.github/get_build_status.py
+++ b/.github/get_build_status.py
@@ -1,5 +1,8 @@
 import requests
 import pandas as pd
+
+pd.set_option("display.max_columns", None)
+pd.set_option("display.max_rows", None)
 slicerExtensionName ='IDCBrowser'
 # API URL
 api_url = f"https://slicer.cdash.org/api/v1/index.php?project=SlicerPreview&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1={slicerExtensionName}"

--- a/.github/get_build_status.py
+++ b/.github/get_build_status.py
@@ -3,7 +3,7 @@ import pandas as pd
 import sys
 pd.set_option("display.max_columns", None)
 pd.set_option("display.max_rows", None)
-slicerExtensionName ='ImageMaker'
+slicerExtensionName ='IDCBrowser'
 # API URL
 api_url = f"https://slicer.cdash.org/api/v1/index.php?project=SlicerPreview&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1={slicerExtensionName}"
 

--- a/.github/get_build_status.py
+++ b/.github/get_build_status.py
@@ -1,0 +1,48 @@
+import requests
+import pandas as pd
+slicerExtensionName ='IDCBrowser'
+# API URL
+api_url = f"https://slicer.cdash.org/api/v1/index.php?project=SlicerPreview&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1={slicerExtensionName}"
+
+# Make the API request and store the JSON response
+response = requests.get(api_url)
+
+if response.status_code == 200:
+    # Parse the JSON response
+    api_result = response.json()
+
+    # Extract the necessary information from the API result
+    api_call_time = api_result["datetime"]
+    builds = api_result["buildgroups"][0]["builds"]
+
+    # Create a list of dictionaries with the desired data
+    data = []
+    for build in builds:
+        build_data = {
+            "APICallTime": api_call_time,
+            "BuildTriggerTime": build["builddate"],
+            "BuildName": build["buildname"],
+            "BuildPlatform": build.get("buildplatform", None),
+            "ConfigureErrors": build.get("configure", {}).get("error", 0),
+            "ConfigureWarnings": build.get("configure", {}).get("warning", 0),
+            "HasCompilationData": build.get("hascompilation", False),
+            "CompilationErrors": build.get("compilation", {}).get("error", 0),
+            "CompilationWarnings": build.get("compilation", {}).get("warning", 0),
+            "HasTestData": build.get("hastest", False),
+            "TestNotRun": build.get("test", {}).get("notrun", 0),
+            "TestFail": build.get("test", {}).get("fail", 0),
+            "TestPass": build.get("test", {}).get("pass", 0),
+        }
+        data.append(build_data)
+
+    # Create a DataFrame
+    df = pd.DataFrame(data)
+    print(df)
+    error_sum = df['ConfigureErrors'].sum()+ df['CompilationErrors'].sum()+df['TestFail'].sum()
+    has_errors = error_sum > 0
+    if has_errors:
+      print("Build Failed")
+    else:
+      print("Build Successful")
+else:
+    print(f"Failed to retrieve data. Status code: {response.status_code}")

--- a/.github/get_build_status.py
+++ b/.github/get_build_status.py
@@ -1,6 +1,6 @@
 import requests
 import pandas as pd
-
+import sys
 pd.set_option("display.max_columns", None)
 pd.set_option("display.max_rows", None)
 slicerExtensionName ='IDCBrowser'
@@ -44,8 +44,8 @@ if response.status_code == 200:
     error_sum = df['ConfigureErrors'].sum()+ df['CompilationErrors'].sum()+df['TestFail'].sum()
     has_errors = error_sum > 0
     if has_errors:
-      print("Build Failed")
+      sys.exit(1)
     else:
-      print("Build Successful")
+      sys.exit(0)
 else:
     print(f"Failed to retrieve data. Status code: {response.status_code}")

--- a/.github/get_build_status.py
+++ b/.github/get_build_status.py
@@ -3,7 +3,7 @@ import pandas as pd
 import sys
 pd.set_option("display.max_columns", None)
 pd.set_option("display.max_rows", None)
-slicerExtensionName ='IDCBrowser'
+slicerExtensionName ='ImageMaker'
 # API URL
 api_url = f"https://slicer.cdash.org/api/v1/index.php?project=SlicerPreview&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1={slicerExtensionName}"
 

--- a/.github/workflows/check_extension_build_status.yml
+++ b/.github/workflows/check_extension_build_status.yml
@@ -26,5 +26,15 @@ jobs:
         python .github/get_build_status.py
       id: error_output
 
+    - name: Set the exit code and send notifications
+      run: |
+        has_errors="${{ steps.error_output.outputs.has_errors }}"
+        if [[ $has_errors == "true" ]]; then
+          echo "Build Failed"
+          # Add your notification steps here
+        else
+          echo "Build Successful"
+        fi
+
     - name: Set the exit code
       run: exit ${{ steps.error_output.outputs.has_errors }}

--- a/.github/workflows/check_extension_build_status.yml
+++ b/.github/workflows/check_extension_build_status.yml
@@ -1,0 +1,22 @@
+name: Check Extension Build Status
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 0 12 */1 * *
+
+jobs:
+  calculate_errors:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Run Python script to calculate errors
+      run: |
+        python .github/get_build_status.py
+      id: error_output
+
+    - name: Set the exit code
+      run: exit ${{ steps.error_output.outputs.has_errors }}

--- a/.github/workflows/check_extension_build_status.yml
+++ b/.github/workflows/check_extension_build_status.yml
@@ -28,5 +28,5 @@ jobs:
       id: error_output
 
     - name: Set the exit code
-      if: env.has_errors
+      if: env.has_errors == 'false'
       run: exit 1

--- a/.github/workflows/check_extension_build_status.yml
+++ b/.github/workflows/check_extension_build_status.yml
@@ -24,17 +24,9 @@ jobs:
     - name: Run Python script to calculate errors
       run: |
         python .github/get_build_status.py
+        echo "has_errors=$has_errors" >> $GITHUB_ENV  
       id: error_output
 
-    - name: Set the exit code and send notifications
-      run: |
-        has_errors="${{ steps.error_output.outputs.has_errors }}"
-        if [[ $has_errors == "true" ]]; then
-          echo "Build Failed"
-          # Add your notification steps here
-        else
-          echo "Build Successful"
-        fi
-
     - name: Set the exit code
-      run: exit ${{ steps.error_output.outputs.has_errors }}
+      if: env.has_errors
+      run: exit 1

--- a/.github/workflows/check_extension_build_status.yml
+++ b/.github/workflows/check_extension_build_status.yml
@@ -11,7 +11,12 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.11
 
     - name: Run Python script to calculate errors
       run: |

--- a/.github/workflows/check_extension_build_status.yml
+++ b/.github/workflows/check_extension_build_status.yml
@@ -24,4 +24,4 @@ jobs:
     - name: Run Python script to calculate errors
       run: |
         python .github/get_build_status.py
-        exit $error_sum
+

--- a/.github/workflows/check_extension_build_status.yml
+++ b/.github/workflows/check_extension_build_status.yml
@@ -18,6 +18,9 @@ jobs:
       with:
         python-version: 3.11
 
+    - name: Install dependencies
+      run: pip install requests==2.31.0 pandas==2.1.1
+
     - name: Run Python script to calculate errors
       run: |
         python .github/get_build_status.py

--- a/.github/workflows/check_extension_build_status.yml
+++ b/.github/workflows/check_extension_build_status.yml
@@ -24,9 +24,4 @@ jobs:
     - name: Run Python script to calculate errors
       run: |
         python .github/get_build_status.py
-        echo "has_errors=$has_errors" >> $GITHUB_ENV  
-      id: error_output
-
-    - name: Set the exit code
-      if: env.has_errors == 'false'
-      run: exit 1
+        exit $error_sum


### PR DESCRIPTION
A simple workflow has been set up to check for errors during the build of the extension, on all target platforms, in any category of the following error categories:

1. Configuration
2. Compilation
3. Test

While warnings are also collected by this workflow, they are ignored to trigger a notification. Although only the configuration error category applies to the IDCBrowser extension, the other two categories are checked as well, to make this workflow robust and applicable to any other extension, that wants to adapt.