### PR TITLE
ENH: Update extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,9 @@ set(EXTENSION_HOMEPAGE "https://github.com/ImagingDataCommons/SlicerIDCBrowser")
 set(EXTENSION_CATEGORY "Informatics")
 set(EXTENSION_CONTRIBUTORS "Andrey Fedorov (SPL and BWH)")
 set(EXTENSION_DESCRIPTION "A Module to explore and access imaging data available from National Cancer Institute Imaging Data Commons.")
-set(EXTENSION_ICONURL "https://raw.githubusercontent.com/ImagingDataCommons/SlicerIDCBrowser/main/IDCBrowser/Resources/Icons/IDCBrowser.png")
+set(EXTENSION_ICONURL "https://raw.githubusercontent.com/ImagingDataCommons/SlicerIDCBrowser/main/IDCBrowser/Resources/Icons/IDCBrowser_alpha.png")
 set(EXTENSION_SCREENSHOTURLS "https://github.com/ImagingDataCommons/SlicerIDCBrowser/blob/main/IDCBrowser/Resources/Screenshot/screenshot.png")
+set(EXTENSION_DEPENDS "QuantitativeReporting")
 
 #-----------------------------------------------------------------------------
 find_package(Slicer REQUIRED)


### PR DESCRIPTION
Consolidate extension metadata based on the corresponding s4ext file organized
in the ExtensionsIndex repository.