### PR TITLE
bug(fix): create images subfolder inside downloadDir, disable dirTemplate

### DIFF
--- a/IDCBrowser/IDCBrowser.py
+++ b/IDCBrowser/IDCBrowser.py
@@ -7,6 +7,8 @@ import csv
 import json
 import logging
 import os.path
+import pathlib
+from pathlib import Path
 import pickle
 import string
 import time
@@ -1060,14 +1062,21 @@ class IDCBrowserWidget(ScriptedLoadableModuleWidget):
         f.close()
       fileName = downloadFolderPath + 'images.zip'
       logging.debug("Downloading images to " + fileName)
-      self.extractedFilesDirectory = downloadFolderPath + 'images'
+      #self.extractedFilesDirectory = downloadFolderPath + 'images'
+
+      downloadFolderPath = Path(downloadFolderPath)  # ensure it's a Path object
+      images_dir = downloadFolderPath / 'images'
+      images_dir.mkdir(parents=True, exist_ok=True)
+      self.extractedFilesDirectory = images_dir
+
       self.progressMessage = "Downloading Images for series InstanceUID: " + selectedSeries
       self.showStatus(self.progressMessage)
       #seriesSize = self.getSeriesSize(selectedSeries)
       logging.debug(self.progressMessage)
       try:
         start_time = time.time()
-        response = self.IDCClient.download_dicom_series(seriesInstanceUID=selectedSeries, downloadDir=self.extractedFilesDirectory)
+        logging.debug(f"selected_series:{selectedSeries}")
+        response = self.IDCClient.download_dicom_series(seriesInstanceUID=selectedSeries, downloadDir=self.extractedFilesDirectory, dirTemplate=None)
         slicer.app.processEvents()
         logging.debug("Downloaded images in %s seconds" % (time.time() - start_time))
 

--- a/IDCBrowser/IDCBrowser.py
+++ b/IDCBrowser/IDCBrowser.py
@@ -605,7 +605,7 @@ class IDCBrowserWidget(ScriptedLoadableModuleWidget):
     manifest_path = os.path.join(downloadDestination,'manifest.csv')
     manifest_df = self.IDCClient.sql_query(query)
     manifest_df.to_csv(manifest_path, index=False, header=False)
-    self.IDCClient.download_from_manifest(manifest_path, downloadDestination)
+    self.IDCClient.download_from_manifest(manifestFile=manifest_path, downloadDir=downloadDestination, dirTemplate=None)
 
   def onDownloadButton(self):
 
@@ -615,7 +615,7 @@ class IDCBrowserWidget(ScriptedLoadableModuleWidget):
     import os
     if(os.path.exists(self.manifestSelector.currentPath)):
       self.download_status.setText('Downloading from manifest...')
-      self.IDCClient.download_from_manifest(self.manifestSelector.currentPath, self.downloadDestinationSelector.directory)
+      self.IDCClient.download_from_manifest(manifestFile=self.manifestSelector.currentPath, downloadDir=self.downloadDestinationSelector.directory, dirTemplate=None)
       self.download_status.setText('Download from manifest done.')
 
     if(self.patientIDSelector.text != ''):


### PR DESCRIPTION
Addresses #36 

I do not know if the images folder inside the series folder was created on the fly previously. This PR uses Pathlib to create the images subfolder and to resolve the series download folder easily.  Secondly, the dirTemplate is set to None in both download_from_manifest and download_dicom_series.