### PR TITLE
BUG: Fix idc-index update when IDCBrowser is the startup module

### DIFF
--- a/IDCBrowser/IDCBrowser.py
+++ b/IDCBrowser/IDCBrowser.py
@@ -1655,8 +1655,6 @@ class IDCBrowserLogic(ScriptedLoadableModuleLogic):
     pass
 
   def setupPythonRequirements(self, update=False):
-    import importlib.metadata
-    import importlib.util
     needToInstall = False
     try:
         import idc_index
@@ -1669,11 +1667,10 @@ class IDCBrowserLogic(ScriptedLoadableModuleLogic):
       errorMessage = f"Failed to {'install' if needToInstall else 'update'} idc-index."
       if needToInstall:
         userMessage = "The module requires idc-index python package, which will now be installed."
-
-      if slicer.util.confirmOkCancelDisplay(userMessage, "SlicerIDCIndex initialization"):
-        with slicer.util.displayPythonShell() as shell, slicer.util.tryWithErrorDisplay(message=errorMessage, waitCursor=True) as errorDisplay:
-          slicer.util.pip_install(f"{'--upgrade ' if update else ''}idc-index>=0.7.0")
-          installed = True
+      logging.info(userMessage)
+      with slicer.util.displayPythonShell() as shell, slicer.util.tryWithErrorDisplay(message=errorMessage, waitCursor=True) as errorDisplay:
+        slicer.util.pip_install(f"{'--upgrade ' if update else ''}idc-index>=0.7.0")
+        installed = True
     else:
       installed = True
 


### PR DESCRIPTION
When IDCBrowser is the startup module, calling confirmOkCancelDisplay will cause the dialog to always be cancelled, preventing the module from being updated. This commit removes the popup, the user already triggers the update by clicking the restart button within the update notice.

Fix #64