### PR TITLE
BUG: Fix download progress bar increments

### DIFF
--- a/IDCBrowser/IDCBrowser.py
+++ b/IDCBrowser/IDCBrowser.py
@@ -1442,15 +1442,15 @@ class IDCBrowserWidget(ScriptedLoadableModuleWidget):
 
   def updateProgressBar(self, currentValue, totalValue, unit="B", description=""):
     units = ["B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB"]
+    self.downloadProgressBar.setMaximum(int(totalValue))
+    self.downloadProgressBar.setValue(int(currentValue))
     for currentUnit in units:
         unit = currentUnit
         if abs(totalValue) < 1000.0 or currentUnit == units[-1]:
             break
         totalValue /= 1000.0
         currentValue /= 1000.0
-    self.downloadProgressBar.setMaximum(int(totalValue))
-    self.downloadProgressBar.setValue(int(currentValue))
-    self.downloadProgressBar.setFormat(f"{description + ' ' if description else ''}%p% (%v{unit}/%m{unit})")
+    self.downloadProgressBar.setFormat(f"{description + ' ' if description else ''}%p% ({currentValue:.2f}{unit}/{totalValue:.2f}{unit})")
     slicer.app.processEvents()
 
   def unzip(self, sourceFilename, destinationDir):


### PR DESCRIPTION
The progress bar value/maximum was being set using values converted into coarser, more user friendly units. This caused an issue since the converted unit size was too coarse to show meaningful progress.

Fixed by setting the progress current/total values in bytes, and displaying the user friendly converted units on the progress bar.

Re #67