### PR TITLE
BUG: Fix error reading invalid collection name

### DIFF
--- a/IDCBrowser/IDCBrowser.py
+++ b/IDCBrowser/IDCBrowser.py
@@ -846,6 +846,11 @@ class IDCBrowserWidget(ScriptedLoadableModuleWidget):
     self.clearStudiesTableWidget()
     self.clearSeriesTableWidget()
     self.selectedCollection = item
+
+    # Check if a valid collection is selected
+    if not self.selectedCollection:
+      return
+
     cacheFile = self.cachePath + self.selectedCollection + '.json'
     self.progressMessage = "Getting available patients for collection: " + self.selectedCollection
 


### PR DESCRIPTION
Previously when an empty/invalid collection is selected it would cause an error when trying to load the selection. Fixed by checking that selectedCollection is valid before attempting to load it.