### PR TITLE
Fix startup collection selection guard

### DIFF
--- a/IDCBrowser/IDCBrowser.py
+++ b/IDCBrowser/IDCBrowser.py
@@ -392,6 +392,10 @@ class IDCBrowserWidget(ScriptedLoadableModuleWidget):
 
     updateStyleJS = """
 (function injectCSS() {
+  const target = document.head || document.documentElement || document.body;
+  if (!target) {
+    return;
+  }
   const css = `
     .site-header,
     .page-heading,
@@ -411,7 +415,7 @@ class IDCBrowserWidget(ScriptedLoadableModuleWidget):
     const s = document.createElement('style');
     s.id = 'hide-hf-style';
     s.textContent = css;
-    (document.head || document.documentElement).appendChild(s);
+    target.appendChild(s);
   }
 })();
 """
@@ -846,6 +850,15 @@ class IDCBrowserWidget(ScriptedLoadableModuleWidget):
     self.clearStudiesTableWidget()
     self.clearSeriesTableWidget()
     self.selectedCollection = item
+
+    if not self.selectedCollection:
+      self.logoLabel.setText("IDC release " + self.logic.idc_version)
+      return
+    if self.selectedCollection not in self.IDCClient.collection_summary.index:
+      logging.warning("collectionSelected: unknown collection '%s'", self.selectedCollection)
+      self.logoLabel.setText("IDC release " + self.logic.idc_version)
+      return
+
     cacheFile = self.cachePath + self.selectedCollection + '.json'
     self.progressMessage = "Getting available patients for collection: " + self.selectedCollection
 


### PR DESCRIPTION
## Summary

This PR fixes startup noise caused by `SlicerIDCBrowser` receiving an empty collection selection while the collection combo box is being repopulated, and hardens the injected portal CSS so it does not throw if the DOM target is not yet available.

## What changed

- Guard `collectionSelected()` against empty collection values
- Guard `collectionSelected()` against unknown collection IDs not present in `IDCClient.collection_summary`
- Reset the label and return cleanly instead of indexing pandas with `''`
- Make the injected portal CSS script no-op safely until a valid DOM target exists

## Why

On opening the extension, the collection selector can briefly emit an empty value during initialization. That caused:

- `KeyError: ''` from `self.IDCClient.collection_summary.loc[self.selectedCollection]`

The portal tab also logged a browser-side error when the script tried to append a style element before the page had a valid insertion target.

This PR removes those avoidable startup errors without changing normal browsing behavior.

## User impact

- Opening the extension no longer produces the `KeyError: ''` traceback
- The portal style injection no longer throws `appendChild` errors during early page load
- Normal collection browsing and patient/study/series loading behavior is unchanged

## Testing

- Opened the extension in Slicer after the fix
- Confirmed the previous `KeyError: ''` traceback no longer appears
- Confirmed the previous portal `appendChild` JavaScript error no longer appears
- Static validation:
  - `env PYTHONPYCACHEPREFIX=/tmp python3 -m py_compile IDCBrowser/IDCBrowser.py`

## Notes

Some remaining console messages still appear to come from Qt WebEngine / Chromium internals rather than this extension’s Python logic.
